### PR TITLE
chore:  mit license header for tools

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+MIT License
+
 Copyright (c) Siemens AG 2023
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
some tools use the header to easier identify the license type