### PR TITLE
Fix deployment commands in docs (sync with README)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ Edgeshark services:
 
 ```bash
 wget -q --no-cache -O - \
-  https://github.com/siemens/edgeshark/raw/main/deployments/nocomposer/edgeshark.sh \
+  https://github.com/siemens/edgeshark/raw/main/deployments/wget/docker-compose.yaml \
   | docker compose -f - up
 ```
 
@@ -46,7 +46,7 @@ simple fallback using a plain `bash` script.
 
 ```bash
 wget -q --no-cache -O - \
-  https://github.com/siemens/edgeshark/raw/main/deployments/bash/docker-compose.yaml \
+  https://github.com/siemens/edgeshark/raw/main/deployments/nocomposer/edgeshark.sh \
   | bash -s up
 ```
 


### PR DESCRIPTION
Docker Compose file should be piped into `docker compose` and Bash script should be piped into `bash`. Not the other way round.