### PR TITLE
chore: Add hostname on gostwire container to support podman

### DIFF
--- a/deployments/edgeshark/docker-compose.yaml
+++ b/deployments/edgeshark/docker-compose.yaml
@@ -3,6 +3,7 @@ version: '2.4'
 services:
     gostwire:
         image: 'gostwire'
+        hostname: 'gostwire.ghost-in-da-edge'
         read_only: true
         mem_limit: 48M
         memswap_limit: 48M

--- a/deployments/wget/docker-compose-5500.yaml
+++ b/deployments/wget/docker-compose-5500.yaml
@@ -5,6 +5,7 @@ name: 'edgeshark'
 services:
     gostwire:
         image: 'ghcr.io/siemens/ghostwire'
+        hostname: 'gostwire.ghost-in-da-edge'
         pull_policy: always
         restart: 'unless-stopped'
         read_only: true

--- a/deployments/wget/docker-compose-localhost.yaml
+++ b/deployments/wget/docker-compose-localhost.yaml
@@ -5,6 +5,7 @@ name: 'edgeshark'
 services:
     gostwire:
         image: 'ghcr.io/siemens/ghostwire'
+        hostname: 'gostwire.ghost-in-da-edge'
         pull_policy: always
         restart: 'unless-stopped'
         read_only: true

--- a/deployments/wget/docker-compose.yaml
+++ b/deployments/wget/docker-compose.yaml
@@ -5,6 +5,7 @@ name: 'edgeshark'
 services:
     gostwire:
         image: 'ghcr.io/siemens/ghostwire'
+        hostname: 'gostwire.ghost-in-da-edge'
         pull_policy: always
         restart: 'unless-stopped'
         read_only: true


### PR DESCRIPTION
When running Edgeshark with [Podman](https://podman.io/), the name "gostwire.ghost-in-da-edge" can't be resolved in the communication between the containers. This PR adds the hostname explicitly to make it work.

