### PR TITLE
Minor Speling[sic] corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ If you want to live capture traffic using Wireshark, please [download the csharg
 extcap plugin](https://github.com/siemens/cshargextcap/releases) for the
 OS/distribution and install it. Please also check the [cshargextcap installation
 instructions](https://github.com/siemens/cshargextcap?tab=readme-ov-file#installation),
-especially for macos users regarding the additional packetflix URL handler
+especially for macOS users regarding the additional packetflix URL handler
 installation.
 
 ## Project Structure

--- a/docs/details.md
+++ b/docs/details.md
@@ -215,7 +215,7 @@ The "**St**" or **state column** signals the socket connection state:
   then shows the IP address and port number of the remote end of the connection.
 
 The "**Group · Container · Process**" column ❸ not only identifies the process
-using a particular socker by name and PID, but additionally the containing
+using a particular socket by name and PID, but additionally the containing
 container (if any).
 
 On Docker hosts, eagle-eyed users might spot a "guest" ❹ opening sockets in IP

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -13,7 +13,7 @@ expressions.
 
 - ❶ the **filter pattern**, either:
   - a **substring** that must be included in a containee's name, Composer
-    porject, or Kubernetes pod,
+    project, or Kubernetes pod,
   - or a [**regular expression**](https://regex101.com/) in
     ECMAScript/JavaScript syntax when the option
     ![regexp](_media/icons/Regexp.svg ':class=mdicon :no-zoom') ❸ is active.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,7 +61,7 @@ alternative composer file, or download and edit it before deploying:
 ```bash
 wget -q --no-cache -O - \
   https://github.com/siemens/edgeshark/raw/main/deployments/wget/docker-compose-5500.yaml \
-  | DOCKER_DEFAULT_PLATFORM= ocker compose -f - up
+  | DOCKER_DEFAULT_PLATFORM= docker compose -f - up
 ```
 
 This exposed Edgeshark on host port 5500 instead.


### PR DESCRIPTION
Minor speling[sic] corrections from reading the documentation.  Constrained to "UK" or "British" English since many words already using that standard.

_By the way, I love the use of "whacky" as the uncommon representation, and I read that as intentional._